### PR TITLE
feat(web): remove framer-motion

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,7 +42,6 @@
     "@tanstack/react-router": "catalog:tanstack",
     "axios": "catalog:node",
     "clsx": "^2.1.0",
-    "framer-motion": "^11.2.10",
     "html-react-parser": "^5.2.2",
     "jwt-decode": "^4.0.0",
     "lucide-react": "catalog:react19",

--- a/apps/web/src/app/assets/icons/Refresh.tsx
+++ b/apps/web/src/app/assets/icons/Refresh.tsx
@@ -1,4 +1,3 @@
-import { motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
 
 type TProps = TRestProps & {
@@ -9,32 +8,23 @@ const RefreshIcon = ({ toggleAnimation, ...rest }: TProps) => {
   const [rotation, setRotation] = useState(0)
 
   useEffect(() => {
-    setRotation(rotation + 180)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setRotation((prev) => prev + 180)
   }, [toggleAnimation])
 
   return (
-    <motion.svg
+    <svg
       key='refresh-icon'
       xmlns='http://www.w3.org/2000/svg'
       viewBox='0 0 512 512'
       fill='currentColor'
       stroke='currentColor'
+      className='transition-transform duration-500 ease-out'
+      style={{ transform: `rotate(${rotation}deg)` }}
       {...rest}
     >
       <title>Refresh</title>
-      <motion.path
-        initial={{ rotate: 0 }}
-        animate={{ rotate: rotation }}
-        transition={{
-          type: 'spring',
-          ease: 'linear',
-          bounce: 0.4,
-          duration: 0.5,
-        }}
-        d='M105.1 202.6c7.7-21.8 20.2-42.3 37.8-59.8c62.5-62.5 163.8-62.5 226.3 0L386.3 160H352c-17.7 0-32 14.3-32 32s14.3 32 32 32H463.5c0 0 0 0 0 0h.4c17.7 0 32-14.3 32-32V80c0-17.7-14.3-32-32-32s-32 14.3-32 32v35.2L414.4 97.6c-87.5-87.5-229.3-87.5-316.8 0C73.2 122 55.6 150.7 44.8 181.4c-5.9 16.7 2.9 34.9 19.5 40.8s34.9-2.9 40.8-19.5zM39 289.3c-5 1.5-9.8 4.2-13.7 8.2c-4 4-6.7 8.8-8.1 14c-.3 1.2-.6 2.5-.8 3.8c-.3 1.7-.4 3.4-.4 5.1V432c0 17.7 14.3 32 32 32s32-14.3 32-32V396.9l17.6 17.5 0 0c87.5 87.4 229.3 87.4 316.7 0c24.4-24.4 42.1-53.1 52.9-83.7c5.9-16.7-2.9-34.9-19.5-40.8s-34.9 2.9-40.8 19.5c-7.7 21.8-20.2 42.3-37.8 59.8c-62.5 62.5-163.8 62.5-226.3 0l-.1-.1L125.6 352H160c17.7 0 32-14.3 32-32s-14.3-32-32-32H48.4c-1.6 0-3.2 .1-4.8 .3s-3.1 .5-4.6 1z'
-      />
-    </motion.svg>
+      <path d='M105.1 202.6c7.7-21.8 20.2-42.3 37.8-59.8c62.5-62.5 163.8-62.5 226.3 0L386.3 160H352c-17.7 0-32 14.3-32 32s14.3 32 32 32H463.5c0 0 0 0 0 0h.4c17.7 0 32-14.3 32-32V80c0-17.7-14.3-32-32-32s-32 14.3-32 32v35.2L414.4 97.6c-87.5-87.5-229.3-87.5-316.8 0C73.2 122 55.6 150.7 44.8 181.4c-5.9 16.7 2.9 34.9 19.5 40.8s34.9-2.9 40.8-19.5zM39 289.3c-5 1.5-9.8 4.2-13.7 8.2c-4 4-6.7 8.8-8.1 14c-.3 1.2-.6 2.5-.8 3.8c-.3 1.7-.4 3.4-.4 5.1V432c0 17.7 14.3 32 32 32s32-14.3 32-32V396.9l17.6 17.5 0 0c87.5 87.4 229.3 87.4 316.7 0c24.4-24.4 42.1-53.1 52.9-83.7c5.9-16.7-2.9-34.9-19.5-40.8s-34.9 2.9-40.8 19.5c-7.7 21.8-20.2 42.3-37.8 59.8c-62.5 62.5-163.8 62.5-226.3 0l-.1-.1L125.6 352H160c17.7 0 32-14.3 32-32s-14.3-32-32-32H48.4c-1.6 0-3.2 .1-4.8 .3s-3.1 .5-4.6 1z' />
+    </svg>
   )
 }
 

--- a/apps/web/src/configs/vitest.setup.ts
+++ b/apps/web/src/configs/vitest.setup.ts
@@ -3,9 +3,6 @@ import '@testing-library/jest-dom'
 import 'vitest-location-mock'
 import '../index.css'
 
-import { MotionGlobalConfig } from 'framer-motion'
-MotionGlobalConfig.skipAnimations = true
-
 const getRandomString = (length = 10) => {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_'
   let result = ''

--- a/apps/web/src/e2e/smoke.spec.ts
+++ b/apps/web/src/e2e/smoke.spec.ts
@@ -1,9 +1,6 @@
 import { expect, test } from '@playwright/test'
-import { MotionGlobalConfig } from 'framer-motion'
 
 test('Smoke Test Screens Page', async ({ page }) => {
-  MotionGlobalConfig.skipAnimations = true
-
   // Load Page and navigate to Screens
   await page.goto('/')
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,9 +351,6 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
-      framer-motion:
-        specifier: ^11.2.10
-        version: 11.18.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       html-react-parser:
         specifier: ^5.2.2
         version: 5.2.6(@types/react@19.2.2)(react@19.2.0)
@@ -6019,20 +6016,6 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
-  framer-motion@11.18.2:
-    resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fromentries@1.3.2:
     resolution: {integrity: sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==}
 
@@ -7299,12 +7282,6 @@ packages:
 
   mobx@6.13.7:
     resolution: {integrity: sha512-aChaVU/DO5aRPmk1GX8L+whocagUUpBQqoPtJk+cm7UOXUk87J4PeWCh6nNmTTIfEhiR9DI/+FnA8dln/hTK7g==}
-
-  motion-dom@11.18.1:
-    resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
-
-  motion-utils@11.18.1:
-    resolution: {integrity: sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -15212,16 +15189,6 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  framer-motion@11.18.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
-    dependencies:
-      motion-dom: 11.18.1
-      motion-utils: 11.18.1
-      tslib: 2.8.1
-    optionalDependencies:
-      '@emotion/is-prop-valid': 1.2.2
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-
   fromentries@1.3.2: {}
 
   fs-exists-sync@0.1.0: {}
@@ -16662,12 +16629,6 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
 
   mobx@6.13.7: {}
-
-  motion-dom@11.18.1:
-    dependencies:
-      motion-utils: 11.18.1
-
-  motion-utils@11.18.1: {}
 
   mrmime@2.0.1: {}
 


### PR DESCRIPTION
This pull request removes the `framer-motion` animation library and its usage from the web application, simplifying the dependencies and the implementation of the `Refresh` icon animation. The animation for the refresh icon is now handled using native CSS transitions and React state, rather than relying on an external library.

**Dependency removal and cleanup:**

* Removed `framer-motion` from `package.json` and all related animation dependencies from `pnpm-lock.yaml`, significantly reducing the project's dependency footprint. [[1]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L45) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL354-L356) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6022-L6035) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7303-L7308) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15215-L15224) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL16666-L16671)

**Codebase simplification:**

* Refactored the `Refresh` icon component in `Refresh.tsx` to use a simple CSS transition and React state for rotation, instead of `framer-motion`. [[1]](diffhunk://#diff-0a036e7ae7e656b0f08674f01bf314825608420d914a0e403f582f49330dee28L1) [[2]](diffhunk://#diff-0a036e7ae7e656b0f08674f01bf314825608420d914a0e403f582f49330dee28L12-R27)
* Removed all references to `MotionGlobalConfig` and related animation skipping logic from test setup and E2E test files, as they are no longer needed without `framer-motion`. [[1]](diffhunk://#diff-c071619fa4b742263380e5699f56e0e26162deb236788fa040e70233b439e3cbL6-L8) [[2]](diffhunk://#diff-a93e385e4d9586a57a268683f0275750e5bbb862e539eb3e201d9330dff2a282L2-L6)