### PR TITLE
fix(web): fix spinner visibility during busy state and linting issues

### DIFF
--- a/apps/web/src/app/components/screen/table/ScreenTable.tsx
+++ b/apps/web/src/app/components/screen/table/ScreenTable.tsx
@@ -245,7 +245,11 @@ export const ScreenTable = ({
                       ))
                       .otherwise(() => null)}
                     {match(deleteHandler)
-                      .with({ isPending: true, id: screen.id }, () => <Loader2 className='size-4 animate-spin' />)
+                      .with({ isPending: true, variables: { id: screen.id } }, () => (
+                        <div className='flex size-9 items-center justify-center'>
+                          <Loader2 className='size-6 animate-spin' />
+                        </div>
+                      ))
                       .with(P.nonNullable, (item) => (
                         <Button
                           title='Delete'

--- a/apps/web/src/app/components/stacked/Stacked.tsx
+++ b/apps/web/src/app/components/stacked/Stacked.tsx
@@ -28,7 +28,7 @@ export const Stacked = ({
   return (
     <div
       className={cn(
-        'inline-grid w-full p-2 [&>*]:col-start-1 [&>*]:row-start-1',
+        'inline-grid w-full p-2 *:col-start-1 *:row-start-1',
         justifyItemsMap[$hAlign ?? HAlignDefault],
         alignItemsMap[$vAlign ?? 'end'],
         className


### PR DESCRIPTION
This pull request introduces minor UI improvements to two components, focusing on better alignment and loading indicators.

UI improvements:

* Updated the loading state in `ScreenTable` to use a larger, centered spinner for a clearer visual indication when deleting a screen.
* Simplified the CSS selector in the `Stacked` component to use the modern `*:` syntax for grid alignment, improving readability and maintainability.